### PR TITLE
UID2-7015: add unit tests for attestation-aws

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -41,6 +41,5 @@ jobs:
       publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
       vulnerability_failure_severity: ${{ inputs.vulnerability_failure_severity }}
       working_dir: attestation-aws
-      skip_tests: true # No tests are present in this repository
       merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,4 +8,3 @@ jobs:
     with:
       working_dir: attestation-aws/
       java_version: 21
-      skip_tests: true # No tests are present in this repository

--- a/attestation-aws/pom.xml
+++ b/attestation-aws/pom.xml
@@ -46,6 +46,18 @@
       <artifactId>uid2-attestation-api</artifactId>
       <version>2.1.6</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/attestation-aws/src/main/java/com/uid2/attestation/aws/NitroAttestation.java
+++ b/attestation-aws/src/main/java/com/uid2/attestation/aws/NitroAttestation.java
@@ -20,7 +20,10 @@ public class NitroAttestation {
     static {
         try {
             System.loadLibrary("jnsm");
-        } catch (UnsatisfiedLinkError ignored) {}
+        } catch (UnsatisfiedLinkError ignored) {
+            // Intentionally ignored in non-Nitro environments (e.g. test JVMs without jnsm).
+            // generateAttestationRequestInternal() will throw UnsatisfiedLinkError on first call.
+        }
     }
 
     private static native int generateAttestationRequestInternal(

--- a/attestation-aws/src/main/java/com/uid2/attestation/aws/NitroAttestation.java
+++ b/attestation-aws/src/main/java/com/uid2/attestation/aws/NitroAttestation.java
@@ -18,7 +18,9 @@ public class NitroAttestation {
     }
 
     static {
-        System.loadLibrary("jnsm");
+        try {
+            System.loadLibrary("jnsm");
+        } catch (UnsatisfiedLinkError ignored) {}
     }
 
     private static native int generateAttestationRequestInternal(

--- a/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationParamsTest.java
+++ b/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationParamsTest.java
@@ -1,0 +1,24 @@
+package com.uid2.attestation.aws;
+
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+public class NitroAttestationParamsTest {
+    @Test
+    public void testConstructorAssignsFields() {
+        byte[] userData = {1, 2, 3};
+        byte[] publicKey = {4, 5};
+        byte[] nonce = {6};
+        NitroAttestationParams p = new NitroAttestationParams(userData, publicKey, nonce);
+        assertArrayEquals(userData, p.userData);
+        assertArrayEquals(publicKey, p.publicKey);
+        assertArrayEquals(nonce, p.nonce);
+    }
+
+    @Test
+    public void testNullNonceAllowed() {
+        NitroAttestationParams p = new NitroAttestationParams(new byte[]{1}, new byte[]{2}, null);
+        assertNull(p.nonce);
+    }
+}

--- a/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationProviderTest.java
+++ b/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationProviderTest.java
@@ -4,6 +4,8 @@ import com.uid2.enclave.AttestationException;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
@@ -17,12 +19,16 @@ public class NitroAttestationProviderTest {
         NitroAttestationRequest stub = new NitroAttestationRequest(fullBuffer, 3);
 
         try (MockedStatic<NitroAttestation> mocked = mockStatic(NitroAttestation.class)) {
-            mocked.when(() -> NitroAttestation.generateAttestationRequest(any())).thenReturn(stub);
+            ArgumentCaptor<NitroAttestationParams> captor = ArgumentCaptor.forClass(NitroAttestationParams.class);
+            mocked.when(() -> NitroAttestation.generateAttestationRequest(captor.capture())).thenReturn(stub);
 
             byte[] result = new NitroAttestationProvider()
                     .getAttestationRequest(new byte[]{9}, new byte[]{8});
 
             assertArrayEquals(new byte[]{1, 2, 3}, result);
+            assertArrayEquals(new byte[]{9}, captor.getValue().publicKey);
+            assertArrayEquals(new byte[]{8}, captor.getValue().userData);
+            assertNull(captor.getValue().nonce);
         }
     }
 
@@ -43,6 +49,7 @@ public class NitroAttestationProviderTest {
 
     @Test
     public void testIsReadyDefaultTrue() {
+        // NitroAttestationProvider delegates to IAttestationProvider.isReady() default (always true)
         assertTrue(new NitroAttestationProvider().isReady());
     }
 }

--- a/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationProviderTest.java
+++ b/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationProviderTest.java
@@ -1,0 +1,48 @@
+package com.uid2.attestation.aws;
+
+import com.uid2.enclave.AttestationException;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+public class NitroAttestationProviderTest {
+
+    @Test
+    public void testReturnsSlicedBuffer() throws AttestationException {
+        byte[] fullBuffer = new byte[20000];
+        fullBuffer[0] = 1; fullBuffer[1] = 2; fullBuffer[2] = 3;
+        NitroAttestationRequest stub = new NitroAttestationRequest(fullBuffer, 3);
+
+        try (MockedStatic<NitroAttestation> mocked = mockStatic(NitroAttestation.class)) {
+            mocked.when(() -> NitroAttestation.generateAttestationRequest(any())).thenReturn(stub);
+
+            byte[] result = new NitroAttestationProvider()
+                    .getAttestationRequest(new byte[]{9}, new byte[]{8});
+
+            assertArrayEquals(new byte[]{1, 2, 3}, result);
+        }
+    }
+
+    @Test
+    public void testWrapsNitroExceptionAsAttestationException() {
+        try (MockedStatic<NitroAttestation> mocked = mockStatic(NitroAttestation.class)) {
+            NitroException root = NitroException.fromErrorCode(-1);
+            mocked.when(() -> NitroAttestation.generateAttestationRequest(any())).thenThrow(root);
+
+            try {
+                new NitroAttestationProvider().getAttestationRequest(new byte[0], new byte[0]);
+                fail("expected AttestationException");
+            } catch (AttestationException e) {
+                assertSame(root, e.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void testIsReadyDefaultTrue() {
+        assertTrue(new NitroAttestationProvider().isReady());
+    }
+}

--- a/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationRequestTest.java
+++ b/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroAttestationRequestTest.java
@@ -1,0 +1,15 @@
+package com.uid2.attestation.aws;
+
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class NitroAttestationRequestTest {
+    @Test
+    public void testGetters() {
+        byte[] data = {10, 20, 30, 0, 0};
+        NitroAttestationRequest r = new NitroAttestationRequest(data, 3);
+        assertArrayEquals(data, r.getData());
+        assertEquals(3, r.getLength());
+    }
+}

--- a/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroExceptionTest.java
+++ b/attestation-aws/src/test/java/com/uid2/attestation/aws/NitroExceptionTest.java
@@ -1,0 +1,17 @@
+package com.uid2.attestation.aws;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class NitroExceptionTest {
+    @Test public void testInvalidArgument()  { assertEquals("Invalid Argument",  NitroException.fromErrorCode(-1).getMessage()); }
+    @Test public void testInvalidIndex()     { assertEquals("Invalid Index",     NitroException.fromErrorCode(-2).getMessage()); }
+    @Test public void testInvalidResponse()  { assertEquals("Invalid Response",  NitroException.fromErrorCode(-3).getMessage()); }
+    @Test public void testReadonlyIndex()    { assertEquals("Readonly Index",    NitroException.fromErrorCode(-4).getMessage()); }
+    @Test public void testInvalidOperation() { assertEquals("Invalid Operation", NitroException.fromErrorCode(-5).getMessage()); }
+    @Test public void testBufferTooSmall()   { assertEquals("Buffer too small",  NitroException.fromErrorCode(-6).getMessage()); }
+    @Test public void testInputTooLarge()    { assertEquals("Input too large",   NitroException.fromErrorCode(-7).getMessage()); }
+    @Test public void testInternalError()    { assertEquals("Internal Error",    NitroException.fromErrorCode(-8).getMessage()); }
+    @Test public void testUnknownPositive()  { assertEquals("Unknown Error",     NitroException.fromErrorCode(42).getMessage()); }
+    @Test public void testUnknownNegative()  { assertEquals("Unknown Error",     NitroException.fromErrorCode(-9).getMessage()); }
+}


### PR DESCRIPTION
## Summary
- Add JUnit 4.13.2 and Mockito 5.12.0 test dependencies to attestation-aws/pom.xml
- Add unit tests: NitroExceptionTest (10), NitroAttestationParamsTest (2), NitroAttestationRequestTest (1), NitroAttestationProviderTest (3) — 16 tests total
- Wrap System.loadLibrary("jnsm") in try-catch UnsatisfiedLinkError in NitroAttestation.java so mockStatic can instrument the class in test environments (no production behavior change)
- Remove skip_tests: true from build-and-test and build-and-publish workflows so CI runs mvn test on PR and publish

## Test plan
- [ ] CI build-and-test workflow runs and reports 16 passing tests
- [ ] All four test classes present: NitroException, NitroAttestationParams, NitroAttestationRequest, NitroAttestationProvider
- [ ] NitroAttestation still loads correctly in production (library present)

## Design decisions

### Why the `result > 0` branch in `generateAttestationRequest` is not directly unit-tested
That method's only collaborator is `private static native generateAttestationRequestInternal`, which has no implementation in a test JVM. Mockito cannot stub private methods, so the branch can't be driven without either (a) relaxing the native method to package-private purely for tests, or (b) pulling in PowerMock to mock a private/native call. Both were rejected:
- (a) is a production change made solely to enable a test.
- (b) is a heavy dependency with poor Java 21 support that diverges from the plain-Mockito style used in `uid2-attestation-gcp` / `uid2-attestation-azure` (which the ticket asks us to mirror).

The branch itself is trivial glue, and its parts are already covered: `NitroException.fromErrorCode` is exhaustively unit-tested (all error codes + unknown paths), and `NitroAttestationProviderTest` covers both the success-slice path and the error → `AttestationException` wrapping path. Verified empirically that there is no zero-production-change way to test it: a `mockStatic` custom-`Answer` attempt to intercept only the inner native call still hits `UnsatisfiedLinkError`, because Mockito does not route the internally-called private static through the mock.

### Why `System.loadLibrary("jnsm")` is wrapped in try-catch
`NitroAttestationProviderTest` uses `mockStatic(NitroAttestation.class)`, which forces the JVM to load and initialize the class. The static initializer's `System.loadLibrary("jnsm")` throws `UnsatisfiedLinkError` in any JVM without the native library (i.e. CI / local test). Without the catch, Mockito's static-mock setup fails (`Internal class redefinition failed: invalid class`) and the provider tests cannot run.

Catching `UnsatisfiedLinkError` is behaviorally inert in production: on a real Nitro enclave `libjnsm.so` is always present, so the class initializes identically to before. The only difference is in a library-absent environment, where the failure shifts from class-load time to first native-call time — `generateAttestationRequestInternal` still throws `UnsatisfiedLinkError` on first use. Verified empirically: reverting to the bare `loadLibrary` call fails exactly the two `mockStatic`-based provider tests (14/16 pass); with the catch all 16 pass.

Jira: UID2-7015
